### PR TITLE
Moved taxonomyService initialization to post config block to avoid database issue

### DIFF
--- a/TaxonomyGrailsPlugin.groovy
+++ b/TaxonomyGrailsPlugin.groovy
@@ -1,4 +1,3 @@
-
 import com.grailsrocks.taxonomy.Taxon
 import com.grailsrocks.taxonomy.TaxonomyService
 
@@ -37,12 +36,7 @@ Add hierarichal tags (taxonomies) to any domain classes.
     }
 
     def doWithDynamicMethods = { ctx ->
-        def taxoService = ctx.taxonomyService
-        
-        // Make sure global taxo is initialized
-        taxoService.init()
-        
-        applyDynamicMethods(application)
+        // Removed initialization of service 
     }
 
     def applyDynamicMethods(application) {
@@ -106,7 +100,12 @@ Add hierarichal tags (taxonomies) to any domain classes.
     }
 
     def doWithApplicationContext = { applicationContext ->
-        // TODO Implement post initialization spring config (optional)
+        def taxoService = applicationContext.taxonomyService
+        
+        // Make sure global taxo is initialized
+        taxoService.init()
+        
+        applyDynamicMethods(application)
     }
 
     def onChange = { event ->


### PR DESCRIPTION
Initialization of taxonomy moved to post initialization block ie "doWithApplicationContext" clouser. Reason is that previously, initialization was happening before Taxonomy table is created, since it was called in "doWithDynamicMethods" clouse which executes before tables are created, hence throwing the exception.

![Screenshot from 2012-12-28 18:26:52](https://f.cloud.github.com/assets/1804514/34020/3ee6356e-50ee-11e2-9614-78ccac8480ae.png)
